### PR TITLE
extension should be lowercase

### DIFF
--- a/copernicus_download/download.py
+++ b/copernicus_download/download.py
@@ -5,7 +5,7 @@ from wget_provider import download_url
 
 logger = logging.getLogger('copernicus_download.download')
 
-def download_data(url, username, password, download_dir='.', data_ext='.ZIP'):
+def download_data(url, username, password, download_dir='.', data_ext='.zip'):
     """Download a url with login using wget"""
     download_subdir = tempfile.mkdtemp(prefix='download_', dir=download_dir)
     downloaded_files = download_url(url,


### PR DESCRIPTION
This makes no difference on Windows, but allows the files to be downloaded on Linux.