### PR TITLE
Use itsybitsy instead of wget_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # copernicus_download
-Download http://land.copernicus.vgt.vito.be/PDF/datapool
+Download from http://land.copernicus.vgt.vito.be/PDF/datapool
 
 ## Installation
 
-You need to have [`wget_provider`](https://github.com/DHI-GRAS/wget_provider) installed. Then run
+You need to have [`itsybitsy`](https://github.com/DHI-GRAS/itsybitsy) installed. Then run
 
     python setup.py install
 
@@ -17,8 +17,8 @@ import copernicus_download as codo
 
 url = codo.build_url(product='SWI', year=2016, month=1, day=1)
 
-local_files = codo.download_data(url, username='user', password='pass', 
-                                 download_dir='.', data_ext='.ZIP')
+local_files = codo.download_data(url, username='user', password='pass',
+                                 download_dir='.', include='*.zip')
 
 h5fname = codo.extract_h5(local_files[0], '.')
 
@@ -38,4 +38,4 @@ From the manual:
 > ?coord=XLL,YLL,XUR,YUR
 > where (XLL,YLL) is the LonLat coordinates of the lower-left corner of the boundingBox and (XUR,YUR)
 > is the LonLat coordinates of the upper-right corner. E.g. ?coord=-10.1,-5.1,10.0,5.0
-> Note: the coord parameter is only supported for PROBA-V synthesis products. 
+> Note: the coord parameter is only supported for PROBA-V synthesis products.

--- a/copernicus_download/config.py
+++ b/copernicus_download/config.py
@@ -1,6 +1,6 @@
 import datetime
 
-datapool_url = 'http://land.copernicus.vgt.vito.be/PDF/////datapool/'
+datapool_url = 'http://land.copernicus.vgt.vito.be/PDF/datapool/'
 
 product_base_urls = {
         'Water_Bodies_Global': 'Water/Water_Bodies/Water_Bodies_Global_V2',

--- a/copernicus_download/download.py
+++ b/copernicus_download/download.py
@@ -49,10 +49,12 @@ def _recursive_download(base_url, download_directory=".", username=None, passwor
         Username required for authentication (default: no authentication)
     password : str
         Password required for authentication (default: no authentication)
-    include : glob pattern
-        Download only matching files (default: download all files)
-    exclude : glob pattern
-        Do not download matching files (default: download all files)
+    include : list of str or str
+        Download only files matching at least one of those glob patterns
+        (default: download all files)
+    exclude : list of str or str
+        Do not download files matching at least one of those glob patterns
+        (default: download all files)
     download_jobs : int
         Number of concurrent jobs used for downloading files (default: 10)
     crawler_args : dict
@@ -126,8 +128,9 @@ def download_data(url, username, password, download_dir='.', include='*.zip'):
         Password for authentication
     download_dir : str
         Directory to save downloaded files to (default: current directory)
-    include : glob pattern
-        Download only files matching this pattern (default: all .zip files)
+    include : list of str or str
+        Download only files matching at least one of those glob patterns
+        (default: all .zip files)
     """
 
     crawler_args = dict( # passed to itsybitsy

--- a/copernicus_download/download.py
+++ b/copernicus_download/download.py
@@ -1,18 +1,148 @@
 import tempfile
 import logging
+import os.path
+import shutil
+import fnmatch
+import warnings
+import concurrent.futures
 
-from wget_provider import download_url
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
+
+import requests
+import itsybitsy
 
 logger = logging.getLogger('copernicus_download.download')
 
-def download_data(url, username, password, download_dir='.', data_ext='.zip'):
-    """Download a url with login using wget"""
+
+def _download_file(url, target, session, max_retries=10):
+    """Download a single file"""
+    retries = 0
+    while True:
+        if retries >= max_retries:
+            logger.warning("could not get file %s", url)
+            break
+        with session.get(url, stream=True) as response:
+            with open(target, "wb") as target_file:
+                shutil.copyfileobj(response.raw, target_file)
+            data_length = response.raw.tell()
+            if not data_length:
+                retries += 1
+                continue
+            break
+    return target
+
+
+def _recursive_download(base_url, download_directory=".", username=None, password=None,
+                       include=None, exclude=None, download_jobs=10, crawler_args=None):
+    """Concurrent recursive downloader using the itsybitsy crawler
+
+    Arguments
+    ---------
+    base_url : str
+        Starting point for crawler
+    download_directory : str
+        Directory to save files to (default: current directory)
+    username : str
+        Username required for authentication (default: no authentication)
+    password : str
+        Password required for authentication (default: no authentication)
+    include : glob pattern
+        Download only matching files (default: download all files)
+    exclude : glob pattern
+        Do not download matching files (default: download all files)
+    download_jobs : int
+        Number of concurrent jobs used for downloading files (default: 10)
+    crawler_args : dict
+        Keyword arguments to pass to itsybitsy.crawl
+    """
+    logger.debug("crawling %s", base_url)
+
+    if crawler_args is None:
+        crawler_args = {}
+
+    with requests.Session() as session:
+        if username and password:
+            session.auth = (username, password)
+
+        if crawler_args.get("session") is None:
+            crawler_args["session"] = session
+
+        crawler = itsybitsy.crawl(base_url, **crawler_args)
+        base_url_normalized = next(crawler)
+        base_path = urlparse.urlparse(base_url_normalized).path
+
+        if isinstance(include, str):
+            include = [include]
+        if isinstance(exclude, str):
+            exclude = [exclude]
+
+        futures = set()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=download_jobs) as executor:
+            for url in crawler:
+                logger.debug("> found link: %s" % url)
+                url_parts = urlparse.urlparse(url)
+                file_path = url_parts.path
+                if not file_path.startswith(base_path):
+                    warnings.warn("File {} does not match base path {} - skipping".format(file_path, base_path))
+                    continue
+
+                target_localpath = os.path.normpath(file_path[len(base_path):])
+                target_fullpath = os.path.join(download_directory, target_localpath)
+
+                if include and not any(fnmatch.fnmatch(target_localpath, pattern) for pattern in include):
+                    logger.debug(">> skipping due to include pattern")
+                    continue
+                if exclude and any(fnmatch.fnmatch(target_localpath, pattern) for pattern in exclude):
+                    logger.debug(">> skipping due to exclude pattern")
+                    continue
+
+                try:
+                    os.makedirs(os.path.dirname(target_fullpath))
+                except OSError:
+                    pass
+
+                logger.debug(">> downloading")
+                future = executor.submit(_download_file, url, target_fullpath, session)
+                futures.add(future)
+
+            if futures:
+                for future in concurrent.futures.as_completed(futures):
+                    yield future.result()
+
+
+def download_data(url, username, password, download_dir='.', include='*.zip'):
+    """Download a URL tree recursively using itsybitsy
+
+    Parameters
+    ----------
+    url : str
+        Starting point for crawler
+    username : str
+        Username for authentication
+    password  : str
+        Password for authentication
+    download_dir : str
+        Directory to save downloaded files to (default: current directory)
+    include : glob pattern
+        Download only files matching this pattern (default: all .zip files)
+    """
+
+    crawler_args = dict( # passed to itsybitsy
+        only_go_deeper=True,
+        max_depth=None,
+        max_retries=10,
+        timeout=100,
+        strip_fragments=True,
+        max_connections=100
+    )
+
     download_subdir = tempfile.mkdtemp(prefix='download_', dir=download_dir)
-    downloaded_files = download_url(url,
-            auth=dict(username=username, password=password),
-            continue_partial=True,
-            recursive=True,
-            cmd_extra=['--ignore-case'],
-            data_ext=data_ext,
-            download_dir=download_subdir)
-    return downloaded_files
+    return _recursive_download(url,
+                               download_directory=download_subdir,
+                               username=username,
+                               password=password,
+                               include=include,
+                               crawler_args=crawler_args)

--- a/copernicus_download/query.py
+++ b/copernicus_download/query.py
@@ -17,6 +17,6 @@ def build_url(product, year, month=None, day=None, extent={}):
             url += '/{}'.format(day)
 
     if extent:
-        url += '/?coord{xmin},{ymin},{xmax},{ymax}'.format(**extent)
+        url += '/?coord={xmin},{ymin},{xmax},{ymax}'.format(**extent)
 
     return url

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     url='https://www.dhi-gras.com',
     packages=find_packages(),
     install_requires=[
-        'wget_provider'],
-    dependency_links=[
-        'https://github.com/DHI-GRAS/wget_provider/archive/v0.1.tar.gz#egg=wget_provider-0.1'])
+            'itsybitsy'
+        ],
+    )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='copernicus_download',
-    version='0.2',
+    version='0.3.0',
     description='Download from land.copernicus.vgt.vito.be/PDF/datapool',
     author='Jonas Solvsteen',
     author_email='josl@dhigroup.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='copernicus_download',
-    version='0.3.0',
+    version='1.0',
     description='Download from land.copernicus.vgt.vito.be/PDF/datapool',
     author='Jonas Solvsteen',
     author_email='josl@dhigroup.com',


### PR DESCRIPTION
Also fixes a critical bug when using the `extent` parameter.

I would like to use `goget` later on instead of directly interfacing `itsybitsy`, but since `goget` is intended to be a Python 3 only library, I don't think we are at this point yet.

Interface-breaking, so do not merge before similar pull requests in other projects!